### PR TITLE
Add dynamic Table of Contents generation system

### DIFF
--- a/Items/Anarchist_cookbook/Book/index.cs
+++ b/Items/Anarchist_cookbook/Book/index.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+class IndexGenerator
+{
+    static void Main()
+    {
+        string directoryPath = "Items/Anarchist_cookbook/Book";
+        string outputPath = Path.Combine(directoryPath, "Index.md");
+
+        var files = Directory.GetFiles(directoryPath, "*.md")
+                             .Select(Path.GetFileName)
+                             .OrderBy(f => f)
+                             .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Index");
+        sb.AppendLine();
+
+        for (int i = 0; i < files.Count; i++)
+        {
+            sb.AppendLine($"{i + 1}. [{Path.GetFileNameWithoutExtension(files[i])}]({files[i]})");
+        }
+
+        File.WriteAllText(outputPath, sb.ToString());
+    }
+}

--- a/Items/Anarchist_cookbook/Book/table_of_contents.cs
+++ b/Items/Anarchist_cookbook/Book/table_of_contents.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+class TableOfContentsGenerator
+{
+    static void Main()
+    {
+        string directoryPath = "Items/Anarchist_cookbook/Book";
+        string outputPath = Path.Combine(directoryPath, "Table_of_contents.md");
+
+        var files = Directory.GetFiles(directoryPath, "*.md")
+                             .Select(Path.GetFileName)
+                             .OrderBy(f => f)
+                             .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Table of contents");
+        sb.AppendLine();
+
+        for (int i = 0; i < files.Count; i++)
+        {
+            sb.AppendLine($"{i + 1}. [{Path.GetFileNameWithoutExtension(files[i])}]({files[i]})");
+        }
+
+        File.WriteAllText(outputPath, sb.ToString());
+    }
+}


### PR DESCRIPTION
Fixes #18

Add dynamic Table of Contents and Index generation system.

* Add `TableOfContentsGenerator` class in `Items/Anarchist_cookbook/Book/table_of_contents.cs` to dynamically generate the Table of Contents based on the files in the `Items/Anarchist_cookbook/Book` directory and save it to `Items/Anarchist_cookbook/Book/Table_of_contents.md`.
* Add `IndexGenerator` class in `Items/Anarchist_cookbook/Book/index.cs` to dynamically generate the Index based on the files in the `Items/Anarchist_cookbook/Book` directory and save it to `Items/Anarchist_cookbook/Book/Index.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Julieisbaka/Dungeon-crawler-world/pull/19?shareId=661a63b9-d428-4b49-8cd8-3e60583f89cc).