### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,6 +38,9 @@
 
 name: .NET Core Desktop
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "Main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Julieisbaka/Dungeon-crawler-world/security/code-scanning/4](https://github.com/Julieisbaka/Dungeon-crawler-world/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's actions, it primarily interacts with the repository's contents (e.g., checking out code, restoring dependencies, and uploading artifacts). Therefore, the `contents: read` permission is sufficient. This change will ensure that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
