### PR TITLE
Potential fix for code scanning alert no. 298: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build Rust Project
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Julieisbaka/Dungeon-crawler-world/security/code-scanning/298](https://github.com/Julieisbaka/Dungeon-crawler-world/security/code-scanning/298)

To fix the problem, add a `permissions` block to the workflow. Since none of the steps require write access to repository contents, issues, or pull requests, the minimal required permission is `contents: read`. This block can be added at the root level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the root level unless different jobs require different permissions. In this case, add the following block after the workflow `name` and before the `on` block in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
